### PR TITLE
Dropdown fix for forms

### DIFF
--- a/Elemental/Components/AeModelForm/AeModelForm.razor
+++ b/Elemental/Components/AeModelForm/AeModelForm.razor
@@ -92,18 +92,19 @@
                                             <CascadingValue Value="@LabelForPropertyFunc" Name="LabelForPropertyFunc">
                                                 <CascadingValue Value="@NotifyArg" Name="Notifier">
                                                     <CascadingValue Value="@LabelsOnTop" Name="LabelsOnTop">
-                                                        @if (IsReadOnly || isCategoryLocked)
-                                        {
-                                                      <AePropertyValueDisplay PropertyInfo="prop" Instance="Model" ModelFormStyle="ModelFormStyle"/>
-                                        }                                        
-                                        else
-                                        {
-                                            if (ModelFormContext.IsDropDown(prop))
-                                            {
-                                                                <AeDropdownPropertyInput PropertyInfo="prop" Instance="Model" ModelFormStyle="ModelFormStyle" />
-                                            }
-                                            else
-                                            {
+                                                        <CascadingValue Value="@AreFieldsNullable" Name="AreFieldsNullable">
+                                                @if (IsReadOnly || isCategoryLocked)
+                                                {
+                                                                <AePropertyValueDisplay PropertyInfo="prop" Instance="Model" ModelFormStyle="ModelFormStyle"/>
+                                                }                                        
+                                                else
+                                                {
+                                                if (ModelFormContext.IsDropDown(prop))
+                                                {
+                                                                    <AeDropdownPropertyInput PropertyInfo="prop" Instance="Model" ModelFormStyle="ModelFormStyle" />
+                                                }
+                                                else
+                                                {
                                                 if (GetNonNullableType(prop) == typeof(string))
                                                 {
                                                                             <AeStringPropertyInput PropertyInfo="prop" Instance="Model" ModelFormStyle="ModelFormStyle" Editable="prop.IsEditable()" />
@@ -158,7 +159,8 @@
                                                 }
                                             }
                                         }
-                                         </CascadingValue>
+                                                        </CascadingValue>
+                                                    </CascadingValue>
                                                 </CascadingValue>
                                             </CascadingValue>
                                         </CascadingValue>
@@ -313,6 +315,8 @@
     [Parameter]
     public bool LabelsOnTop { get; set; }
 
+    [Parameter]
+    public bool AreFieldsNullable { get; set; }
     [Parameter]
     public bool Flexbox { get; set; }
 

--- a/Elemental/Components/AeModelForm/Internal/AeDropdownPropertyInput.razor
+++ b/Elemental/Components/AeModelForm/Internal/AeDropdownPropertyInput.razor
@@ -39,6 +39,9 @@ else
 
     [Parameter] public ModelFormStyle ModelFormStyle { get; set; }
 
+    [CascadingParameter(Name = "AreFieldsNullable")]
+    public bool AreFieldsNullable { get; set; } = false;
+
     public const int NO_VALUE = -1;
 
     private List<string> ValidDisplayValues { get; set; }
@@ -135,8 +138,9 @@ else
                 }
                 else if (currentIndex == NO_VALUE)
                 {
-                    PropertyInfo.SetValue(Instance, string.Empty);
-                    valueChangedCallback.InvokeAsync(string.Empty);
+                    var instanceValue = AreFieldsNullable ? null : string.Empty;
+                    PropertyInfo.SetValue(Instance, instanceValue);
+                    valueChangedCallback.InvokeAsync(instanceValue);
                 }
             }
         }

--- a/Elemental/Components/AeModelForm/Internal/AeDropdownPropertyInput.razor
+++ b/Elemental/Components/AeModelForm/Internal/AeDropdownPropertyInput.razor
@@ -122,7 +122,7 @@ else
 
     public int InputSelectIndex
     {
-        get => currentIndex; //PropertyInfo.GetValue(Instance);
+        get => currentIndex; 
         set
         {
             if (currentIndex != value)
@@ -133,8 +133,12 @@ else
                     PropertyInfo.SetValue(Instance, ActualValues[currentIndex]);
                     valueChangedCallback.InvokeAsync(ActualValues[currentIndex]);
                 }
+                else if (currentIndex == NO_VALUE)
+                {
+                    PropertyInfo.SetValue(Instance, string.Empty);
+                    valueChangedCallback.InvokeAsync(string.Empty);
+                }
             }
-            //OnChangeCallback.InvokeAsync(new ModelFormChangeArgs() { Context = ModelFormContext<T>, PropertyInfo = PropertyInfo, EditContext = new EditContext(PropertyInfo) });
         }
     }
 


### PR DESCRIPTION
When selecting the placeholder in non-required dropdowns, the instance wasnt being updated to an empty string. Basically, it wasnt possible to unselect drop downs.